### PR TITLE
Fix StopIteration error for HEAD requests

### DIFF
--- a/flask_lambda/__init__.py
+++ b/flask_lambda/__init__.py
@@ -127,13 +127,16 @@ class FlaskLambda(Flask):
             body = next(self.wsgi_app(
                 make_environ(event, context),
                 response.start_response
-            ))
-
-            return {
+            ), None )
+            ret_dict = { 
                 'statusCode': response.status,
-                'headers': response.response_headers,
-                'body': body.decode('utf-8')
+                'headers': response.response_headers
             }
+
+            if body:
+            	ret_dict['body'] = body.decode('utf-8')
+            	
+            return ret_dict
 
         except:
             self.logger.exception('An unexpected exception occured')


### PR DESCRIPTION
HEAD requests don't return a response body, so the `next()` returns a StopIteration exception when trying to create a response. This fix correctly handles not returning a body.